### PR TITLE
Implement bug fix for paths

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,10 @@ export const createValidUri = (host: string, path: string): string => {
 		return path;
 	}
 
+	if (path.startsWith('http') || path.startsWith('https')) {
+		return path;
+	}
+
 	const updatedPath = path.replace('/', '');
 	return `${host}${updatedPath}`;
 };

--- a/test/util.ts
+++ b/test/util.ts
@@ -10,3 +10,8 @@ test('returns the path', t => {
 	const result: string = createValidUri('https://github.com/', 'https://github.com/rocktimsaikia');
 	t.is(result, 'https://github.com/rocktimsaikia');
 });
+
+test('returns CDN paths', t => {
+	const result: string = createValidUri('https://medium.com/', 'https://cdn-static-1.medium.com/_/fp/icons/Medium-Avatar-500x500.svg');
+	t.is(result, 'https://cdn-static-1.medium.com/_/fp/icons/Medium-Avatar-500x500.svg');
+});


### PR DESCRIPTION
Sometimes path may be a CDN url. Eg. when `url = https://medium.com` the favicon `href = https://cdn-static-1.medium.com/_/fp/icons/Medium-Avatar-500x500.svg`, and we need to just handle this case and return it.